### PR TITLE
Fixit dex standard port

### DIFF
--- a/cloudformation/openondemand.yml
+++ b/cloudformation/openondemand.yml
@@ -359,16 +359,6 @@ Resources:
       GroupDescription: Security Group for ALB
       SecurityGroupIngress:
         - CidrIp: !Ref PortalAllowedIPCIDR
-          FromPort: 5556
-          ToPort: 5556
-          IpProtocol: tcp
-          Description: OpenDEX Auth URL
-        - CidrIp: !Ref PortalAllowedIPCIDR
-          FromPort: 5554
-          ToPort: 5554
-          IpProtocol: tcp
-          Description: OpenDEX Auth URL
-        - CidrIp: !Ref PortalAllowedIPCIDR
           FromPort: 443
           ToPort: 443
           IpProtocol: tcp
@@ -381,26 +371,6 @@ Resources:
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName} - ALB SecurityGroup'
-
-  ALBSecurityGroupEgressDEX:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      IpProtocol: tcp
-      FromPort: 5556
-      ToPort: 5556
-      Description: OpenDEX Auth URL
-      GroupId: !GetAtt ALBSecurityGroup.GroupId
-      DestinationSecurityGroupId: !GetAtt PortalSecurityGroup.GroupId
-
-  ALBSecurityGroupEgressDEXSSL:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      IpProtocol: tcp
-      FromPort: 5554
-      ToPort: 5554
-      Description: OpenDEX Auth URL
-      GroupId: !GetAtt ALBSecurityGroup.GroupId
-      DestinationSecurityGroupId: !GetAtt PortalSecurityGroup.GroupId
 
   ALBSecurityGroupEgressHTTP:
     Type: AWS::EC2::SecurityGroupEgress
@@ -428,16 +398,6 @@ Resources:
       GroupDescription: Security Group for OOD Portal Cluster
       VpcId: !Ref VPC
       SecurityGroupIngress:
-        - SourceSecurityGroupId: !Ref ALBSecurityGroup
-          FromPort: 5556
-          ToPort: 5556
-          IpProtocol: tcp
-          Description: OpenDEX Auth URL
-        - SourceSecurityGroupId: !Ref ALBSecurityGroup
-          FromPort: 5554
-          ToPort: 5554
-          IpProtocol: tcp
-          Description: OpenDEX Auth URL
         - SourceSecurityGroupId: !Ref ALBSecurityGroup
           FromPort: 80
           ToPort: 80
@@ -553,16 +513,6 @@ Resources:
       Description: Allows outbound from portal to LDAP
       GroupId: !GetAtt PortalSecurityGroup.GroupId
       CidrIp: 10.0.0.0/16
-
-  PortalHeadNodeDexMetadata:
-    Type: AWS::EC2::SecurityGroupEgress
-    Properties:
-      IpProtocol: tcp
-      FromPort: 5554
-      ToPort: 5554
-      Description: Allows outbound from portal to Dex metadata endpoint
-      GroupId: !GetAtt PortalSecurityGroup.GroupId
-      CidrIp: 0.0.0.0/0
 
   PortalHeadNodeSSHEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -903,7 +853,6 @@ Resources:
         - !Ref PrivateSubnet2
       TargetGroupARNs:
         - !Ref OpenOnDemandTargetGroupHTTPS
-        - !Ref OpenOnDemandDEXTargetGroup
       Tags:
         - Key: Name
           Value: !Sub OpenOnDemand Portal - ${AWS::StackName}-cfn-init
@@ -1016,31 +965,6 @@ Resources:
       Certificates:
         - CertificateArn: !Ref OODCertificate
       Port: 443
-      Protocol: "HTTPS"
-      SslPolicy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
-
-  OpenOnDemandDEXTargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      HealthCheckEnabled: true
-      HealthCheckIntervalSeconds: 6
-      HealthCheckTimeoutSeconds: 5
-      HealthCheckPath: /.well-known/openid-configuration
-      TargetType: instance
-      Protocol: HTTPS
-      Port: 5554
-      VpcId: !Ref VPC
-
-  OpenOnDemandDEXListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      DefaultActions:
-        - Type: forward
-          TargetGroupArn: !Ref OpenOnDemandDEXTargetGroup
-      LoadBalancerArn: !Ref ALB
-      Port: 5554
-      Certificates:
-        - CertificateArn: !Ref OODCertificate
       Protocol: "HTTPS"
       SslPolicy: ELBSecurityPolicy-TLS-1-2-Ext-2018-06
 

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -5,7 +5,7 @@ dnf module enable nodejs:12 -y
 
 # yum install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm -y -q
 
-yum install openssl ondemand-2.0.28 ondemand-selinux ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
+yum install openssl ondemand-2.0.28 ondemand-selinux-2.0.28 ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
 
 export AD_SECRET=$(aws secretsmanager --region $AWS_REGION get-secret-value --secret-id $AD_SECRET_ID --query SecretString --output text)
 export AD_PASSWORD=$(aws secretsmanager --region $AWS_REGION get-secret-value --secret-id $AD_PASSWORD --query SecretString --output text)

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -5,7 +5,7 @@ dnf module enable nodejs:12 -y
 
 yum install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm -y -q
 
-yum install openssl ondemand ondemand-selinux ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
+yum install openssl ondemand-2.0.28 ondemand-selinux ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
 
 export AD_SECRET=$(aws secretsmanager --region $AWS_REGION get-secret-value --secret-id $AD_SECRET_ID --query SecretString --output text)
 export AD_PASSWORD=$(aws secretsmanager --region $AWS_REGION get-secret-value --secret-id $AD_PASSWORD --query SecretString --output text)

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -3,9 +3,9 @@
 dnf module enable ruby:2.7 -y
 dnf module enable nodejs:12 -y
 
-# yum install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm -y -q
+yum install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm -y -q
 
-yum install openssl ondemand-2.0.28 ondemand-selinux-2.0.28 ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
+yum install openssl ondemand-2.0.28 ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
 
 export AD_SECRET=$(aws secretsmanager --region $AWS_REGION get-secret-value --secret-id $AD_SECRET_ID --query SecretString --output text)
 export AD_PASSWORD=$(aws secretsmanager --region $AWS_REGION get-secret-value --secret-id $AD_PASSWORD --query SecretString --output text)

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -3,7 +3,7 @@
 dnf module enable ruby:2.7 -y
 dnf module enable nodejs:12 -y
 
-yum install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm -y -q
+# yum install https://yum.osc.edu/ondemand/2.0/ondemand-release-web-2.0-1.noarch.rpm -y -q
 
 yum install openssl ondemand-2.0.28 ondemand-selinux ondemand-dex krb5-workstation samba-common-tools amazon-efs-utils -y -q
 

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -20,8 +20,8 @@ ssl:
 EOF
 
 cat << EOF >> /etc/ood/config/ood_portal.yml
+dex_uri: /dex
 dex:
-    client_id: $WEBSITE_DOMAIN
     ssl: true
     connectors:
         - type: ldap


### PR DESCRIPTION
*Description of changes:* Updates the DEX configuration to be served by the Apache reverse proxy, enabling us to remove the ALB listener and Security Group rules that permitted access to Dex over 5554


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
