### PR TITLE
Bugfix for upload_pcluster_configs.sh

### DIFF
--- a/scripts/upload_pcluster_configs.sh
+++ b/scripts/upload_pcluster_configs.sh
@@ -2,7 +2,6 @@
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-CLUSTER_CONFIG_BUCKET=<>
 aws s3 cp pcluster_head_node.sh s3://$CLUSTER_CONFIG_BUCKET/pcluster_head_node.sh
 aws s3 cp pcluster_worker_node.sh s3://$CLUSTER_CONFIG_BUCKET/pcluster_worker_node.sh
 aws s3 cp pcluster_worker_node_desktop.sh s3://$CLUSTER_CONFIG_BUCKET/pcluster_worker_node_desktop.sh


### PR DESCRIPTION
*Description of changes:*
Removing `CLUSTER_CONFIG_BUCKET` from `upload_pcluster_configs.sh`.  This value is setup as an environment variable in the cloudformation template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
