### PR TITLE
Bugfix: Removing backticks from bin_overrides.py

### DIFF
--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -169,7 +169,7 @@ import sys
 import yaml
 
 '''
-An example of a `bin_overrides` replacing Slurm `sbatch` for use with Open OnDemand.
+An example of a "bin_overrides" replacing Slurm "sbatch" for use with Open OnDemand.
 Executes sbatch on the target cluster vs OOD node to get around painful experiences with sbatch + EFA.
 
 Requirements:


### PR DESCRIPTION
*Description of changes:*
Addresses a minor issue where the **cfn-init** logs will indicate an error occurred (example below).  The issue is related to backticks included within the comments of the `install-ood.sh` script.

```
2023-10-16 15:29:39,687 P1273 [INFO]    ./install_ood.sh: line 160: bin_overrides: command not found
2023-10-16 15:29:39,687 P1273 [INFO]    sbatch: error: Batch script is empty!
2023-10-16 15:29:39,687 P1273 [INFO] ------------------------------------------------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
