### PR TITLE
Open OnDemand v3.1.1 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,26 +51,34 @@ In your Parallel Cluster config, you must set the following values:
 
 #### Optional - Enable pam_slurm_adopt module for Parallel Cluster compute nodes
 
-The [pam_slurm_adopt](https://slurm.schedmd.com/pam_slurm_adopt.html) module can be enabled on the Compute nodes within ParallelCluster to prevent users from sshing into nodes that they do not have a running job on.  
+The [pam_slurm_adopt](https://slurm.schedmd.com/pam_slurm_adopt.html) module can be enabled on Compute nodes in ParallelCluster to prevent users from ssh'ing to nodes they do not have a job running.
 
-In your Parallel Cluster config, you must set the following values:
+In your Parallel Cluster config, update the following configuration(s):
 
-1/ Enable the [PrologFlags: "contain"](https://slurm.schedmd.com/pam_slurm_adopt.html#important) should be in place to determine if any jobs have been allocated.  This can be set within the `Scheduling` section.
+1/ Check if any steps have been launched.
 
+Add the **CustomSlurmSetting** `PrologFlags: "contain"` in the [Scheduling](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html) section.  Refer to [slurm configuration](https://slurm.schedmd.com/pam_slurm_adopt.html#important) documentation for more details on this slurm setting.
+
+*example*
 ```
   SlurmSettings:  
     CustomSlurmSettings:
       - PrologFlags: "contain"
 ```
 
-2/ [ExclusiveUser](https://slurm.schedmd.com/slurm.conf.html#OPT_ExclusiveUser) should be set to **YES** to cause nodes to be exclusively allocated to users.  This can be set within the `SlurmQueues` section.
+2/ Ensure compute nodes are exclusively allocated to users.  
 
+Add the **CustomSlurmSetting** `ExclusiveUser: "YES"` in the [SlurmQueues](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#Scheduling-v3-SlurmQueues) section.  Refer to [slurm partition configuration](https://slurm.schedmd.com/slurm.conf.html#OPT_ExclusiveUser) for more details.
+
+*example*
 ```
   CustomSlurmSettings:
     ExclusiveUser: "YES"
 ```
 
-3/ A new script [scripts/configure_pam_slurm_adopt.sh](scripts/configure_pam_slurm_adopt.sh) can be added to the `OnNodeConfigured` configuration within the `SlurmQueues` section to run a sequence of scripts.  
+3/ Add [configure_pam_slurm_adopt.sh](scripts/configure_pam_slurm_adopt.sh) to **OnNodeConfigured** in the [CustomActions](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#Scheduling-v3-SlurmQueues-CustomActions) section.  
+
+*example*
 ```
     CustomActions:
       OnNodeConfigured:

--- a/cloudformation/openondemand.yml
+++ b/cloudformation/openondemand.yml
@@ -1237,7 +1237,10 @@ Resources:
           RoleArn: !GetAtt EventBridgeRole.Arn
           Input: !Sub |
            {
-            "commands": ["aws s3 sync s3://${ClusterConfigBucket}/clusters /etc/ood/config/clusters.d/"]
+            "commands": [
+              "aws s3 sync s3://${ClusterConfigBucket}/clusters /etc/ood/config/clusters.d/",
+              "/etc/ood-install/open-on-demand-on-aws-${Branch}/scripts/configure_cluster_for_ood.sh"
+            ]
            }
           RunCommandParameters:
             RunCommandTargets:
@@ -1269,10 +1272,11 @@ Resources:
                     "IFS='/ ' read -r -a array <<< '<stackName>'",
                     "stackName=${!array[1]}",
                     "tags=$(aws cloudformation describe-stacks --stack-name $stackName --region ${AWS::Region} --query \"Stacks[0].Tags[?Key=='parallelcluster:version']\" --output text)",
-                    "if [ ! -z \"$tags\" ];",
-                    "then",
+                    "if [ ! -z \"$tags\" ]; then",
                     " aws s3 rm s3://${ClusterConfigBucket}/clusters/$stackName.yml",
                     " rm /etc/ood/config/clusters.d/$stackName.yml",
+                    " rm /etc/ood/config/apps/bc_desktop/$stackName.yml",
+                    " rm /etc/ssh/ssh_config.d/ood_$stackName.conf",
                     " sacctmgr remove cluster $stackName -i",
                     "fi"
                   ]

--- a/cloudformation/openondemand.yml
+++ b/cloudformation/openondemand.yml
@@ -68,55 +68,54 @@ Parameters:
     Type: String
   SlurmVersion:
     Description: Verion of slurm to install
-    Default: 23.02.5
+    Default: 23.11.4
     Type: String
 Mappings:
-  # Ubuntu 22.04
   RegionMap:
     us-east-1:
-      AMIID: ami-0408adfcef670a71e
+      AMIID: ami-0d7a109bf30624c99
       ALBLogAccount: 127311923021
     us-east-2:
-      AMIID: ami-004dae62019936191
+      AMIID: ami-0e0bf53f6def86294
       ALBLogAccount: 033677994240
     us-west-1:
-      AMIID: ami-035663315c4daae24
+      AMIID: ami-0ce6d733b60360890
       ALBLogAccount: 027434742980
     us-west-2:
-      AMIID: ami-0f1a3eb997d0e161a
+      AMIID: ami-07bff6261f14c3a45
       ALBLogAccount: 797873946194
     ap-northeast-1:
-      AMIID: ami-06f25f372d5d98da3
+      AMIID: ami-034c9ca2bdde7b472
       ALBLogAccount: 582318560864
     ap-northeast-2:
-      AMIID: ami-0610630c2df4f6edd
+      AMIID: ami-0ac9b8202b45eeb08
       ALBLogAccount: 600734575887
     ap-south-1:
-      AMIID: ami-078bee86ac7c5ec2d
+      AMIID: ami-013168dc3850ef002
       ALBLogAccount: 718504428378
     ap-southeast-1:
-      AMIID: ami-081ab28ecb8f9f07f
+      AMIID: ami-015f72d56355ebc27
       ALBLogAccount: 114774131450
     ap-southeast-2:
-      AMIID: ami-02e33cab84ad3b7e5
+      AMIID: ami-004c37117ce961527
       ALBLogAccount: 783225319266
     ca-central-1:
-      AMIID: ami-0d4b8b87818b26421
+      AMIID: ami-0ed90a3b5bde5e371
       ALBLogAccount: 985666609251
     eu-central-1:
-      AMIID: ami-0071fbe485985432e
+      AMIID: ami-01be94ae58414ab2e
       ALBLogAccount: 054676820928
     eu-north-1:
-      AMIID: ami-0d534fbf90e256d14
+      AMIID: ami-079ae45378903f993
       ALBLogAccount: 027434742980
     eu-west-1:
-      AMIID: ami-01b1f2cdbfcb3644e
+      AMIID: ami-074254c177d57d640
       ALBLogAccount: 156460612806
     eu-west-2:
-      AMIID: ami-0103fdca60001bd3c
+      AMIID: ami-03c07bedab170b21a
       ALBLogAccount: 652711504416
     eu-west-3:
-      AMIID: ami-0f2c91ec8df4bde48
+      AMIID: ami-06f64fb0331ab61a0
       ALBLogAccount: 009996457667
 Resources:
 
@@ -378,6 +377,8 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::${AWS::Region}-aws-parallelcluster/*
               - !Sub arn:${AWS::Partition}:s3:::dcv-license.${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::cloudformation-waitcondition-${AWS::Region}/*
+              - !Sub arn:${AWS::Partition}:s3:::al2023-repos-${AWS::Region}-de612dc2/*
+
           - Effect: Allow # Allows access to buckets required for systems manager
             Principal: "*"
             Action: "s3:GetObject"
@@ -390,7 +391,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::patch-baseline-snapshot-${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::aws-ssm-${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::aws-patchmanager-macos-${AWS::Region}/*
-
+              - !Sub arn:${AWS::Partition}:s3:::al2023-repos-${AWS::Region}-de612dc2/*
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -670,6 +671,12 @@ Resources:
               - !Ref OpenOnDemandSecrets
               - !Ref AuroraMasterSecret
           - Effect: Allow
+            Action: 
+              - secretsmanager:GetSecretValue
+              - secretsmanager:PutSecretValue
+            Resource:
+              - !Ref MungeKeySecret
+          - Effect: Allow
             Action:
               - s3:GetObject
               - s3:PutObject
@@ -753,6 +760,13 @@ Resources:
         - Key: idle_timeout.timeout_seconds # Required to address issue with OOD SSH timeout
           Value: 600          
 
+  # Add a new secrets manager entry
+  MungeKeySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Munge Key for Open OnDemand
+      Name: !Sub [ "MungeKey-${StackIdSuffix}", { StackIdSuffix: !Select [ 1, !Split [ '/', !Ref 'AWS::StackId' ] ] } ]
+
   OpenOnDemandLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
     Metadata:
@@ -768,16 +782,16 @@ Resources:
           commands:
             initsetupcmd:
               command: |
-                apt update -y -q
-                sed -i "/#\$nrconf{restart} = 'i';/s/.*/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+                dnf update -y -q
+                #sed -i "/#\$nrconf{restart} = 'i';/s/.*/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
                 touch /var/log/install.txt
         config:
           packages:
-            apt:
-              awscli: []
+            yum:
               jq: []
               realmd: []
               sssd: []
+              amazon-cloudwatch-agent: []
           commands:
             initial_setup:
               command: |
@@ -801,6 +815,7 @@ Resources:
                 export EFS_ID=${SharedFileSystem}
                 export CLUSTER_CONFIG_BUCKET=${ClusterConfigBucket}
                 export SLURM_VERSION=${SlurmVersion}
+                export MUNGEKEY_SECRET_ID=${MungeKeySecret}
               mode: "000744"
               owner: "root"
               group: "root"
@@ -835,7 +850,7 @@ Resources:
             1_install_munge:
               command: |
                 . /etc/ood-install/set_variables.sh
-                ./install_munge.sh
+                ./install_munge.sh 
               cwd: !Sub /etc/ood-install/open-on-demand-on-aws-${Branch}/scripts
             2_install_slurm:
               command: |
@@ -1387,11 +1402,14 @@ Resources:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
-            Action: secretsmanager:GetSecretValue
+            Action: 
+              - secretsmanager:GetSecretValue
+              - secretsmanager:DescribeSecret
             Resource:
               - !Ref OpenOnDemandSecrets
               - !Ref AuroraMasterSecret
               - !Ref ADAdministratorSecret
+              - !Ref MungeKeySecret
           - Effect: Allow
             Action:
               - s3:GetObject
@@ -1463,6 +1481,9 @@ Outputs:
   DBSecretId:
     Description: DB Secret ARN
     Value: !Ref AuroraMasterSecret
+  MungeKeySecretId:
+    Description: Munge Key Secret ARN
+    Value: !Ref MungeKeySecret
   EFSMountId:
     Description: EFS Mount ID
     Value: !Ref SharedFileSystem

--- a/scripts/configure_cloudwatch_metrics.sh
+++ b/scripts/configure_cloudwatch_metrics.sh
@@ -2,11 +2,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-wget -O /tmp/amazon-cloudwatch-agent.deb https://amazoncloudwatch-agent.s3.amazonaws.com/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
-dpkg -i -E /tmp/amazon-cloudwatch-agent.deb
-
-touch /opt/aws/amazon-cloudwatch-agent/bin/config.json
-cat << EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
+cat << EOF > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 {
         "agent": {
                 "metrics_collection_interval": 60,
@@ -100,4 +96,4 @@ cat << EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
 }
 EOF
 
-/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/bin/config.json
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json

--- a/scripts/configure_cluster_for_ood.sh
+++ b/scripts/configure_cluster_for_ood.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script generates SSH configuration files for OOD clusters.
+# It iterates over the cluster configurations and generates a SSH configuration
+# file for each cluster. 
+
+
+set -euo pipefail
+
+# Iterate over the cluster configurations and generate a SSH configuration
+for cluster_config in $(ls -1 /etc/ood/config/clusters.d/*.yml); do
+  cluster_name=$(basename $cluster_config .yml)
+
+  # Get the cluster host from the configuration file
+  cluster_host=$(yq -r '.v2.login.host' $cluster_config)
+  
+  # Generate SSH configuration
+  echo "[-] Generating SSH configuration for $cluster_name..."
+  cat << EOF > /etc/ssh/ssh_config.d/ood_${cluster_name}.conf
+Host ${cluster_host}
+  LogLevel Error
+  StrictHostKeyChecking no
+  UserKnownHostsFile=/dev/null
+  PasswordAuthentication no
+EOF
+done
+
+echo "[+] SSH configuration generated successfully."
+
+# Add open ondemand desktop configuration
+# This configuration assumes there will be slurm queue called 'desktop'
+cat << EOF > /etc/ood/config/apps/bc_desktop/${cluster_name}.yml
+---
+title: "Linux Desktop on ${cluster_name}"
+cluster: "${cluster_name}"
+attributes:
+  desktop: "mate"
+  bc_queue: "desktop"
+  account: "enduser-research-account"
+EOF

--- a/scripts/configure_mkhomedir.sh
+++ b/scripts/configure_mkhomedir.sh
@@ -6,7 +6,7 @@ authselect select sssd with-mkhomedir --force
 systemctl enable sssd.service --now
 systemctl enable oddjobd.service --now
 
-authconfig --enablesssd --enablesssdauth --enablemkhomedir --updateall
+authselect select sssd with-mkhomedir
 sed -e '/PasswordAuthentication no/ s/^#*/#/' -i /etc/ssh/sshd_config
 sed -i '/#PasswordAuthentication yes/s/^#//g' /etc/ssh/sshd_config
 sudo systemctl restart sshd

--- a/scripts/configure_mkhomedir.sh
+++ b/scripts/configure_mkhomedir.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-apt install sssd sssd-ldap oddjob-mkhomedir oddjob -y -q
+dnf install sssd sssd-ldap oddjob-mkhomedir oddjob -y -q
 authselect select sssd with-mkhomedir --force
 systemctl enable sssd.service --now
 systemctl enable oddjobd.service --now

--- a/scripts/install_munge.sh
+++ b/scripts/install_munge.sh
@@ -1,28 +1,30 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-DEBIAN_FRONTEND=noninteractive apt install munge libmunge-dev libmunge2 libssh2-1-dev man2html sshpass -y -q
+dnf install munge munge-libs munge-devel libssh2-devel sshpass -y -q
 
-# Try to copy down the file
+# Write munge key if a value exists in the secret value
+MUNGEKEY_SECRET=$(aws secretsmanager get-secret-value \
+    --secret-id "${MUNGEKEY_SECRET_ID}" \
+    --query SecretString \
+    --output text 2> /dev/null) 
 
-echo "Copying munge key from ${CLUSTER_CONFIG_BUCKET} if found" >> /var/log/install.txt
-# Try to copy down the file if it exists
-aws s3api head-object --bucket $CLUSTER_CONFIG_BUCKET --key munge.key || NOT_EXIST=true
-if [ ! $NOT_EXIST ]; then
-  aws s3 cp s3://$CLUSTER_CONFIG_BUCKET/munge.key /etc/munge/munge.key
-fi
-
-# If the file doesn't exist, then we need to create it
-if [[ ! -e /etc/munge/munge.key ]]; then
+if [[ -z $MUNGEKEY_SECRET ]]; then
     echo "munge key does not exist, creating..." >> /var/log/install.txt
-    dd if=/dev/urandom bs=1 count=1024 > /etc/munge/munge.key # From here: https://docs.01.org/clearlinux/latest/tutorials/hpc.html
+    dd if=/dev/random bs=128 count=1 > /etc/munge/munge.key # From here: https://docs.01.org/clearlinux/latest/tutorials/hpc.html
+
+    # base64 encode the munge key and add to secrets manager
+    MUNGEKEY_SECRET_ENCODED=$(base64 -w0 /etc/munge/munge.key)
+
+    aws secretsmanager put-secret-value \
+    --secret-id "${MUNGEKEY_SECRET_ID}" \
+    --secret-string "$MUNGEKEY_SECRET_ENCODED"
 else
     echo "munge key already exists, skipping..." >> /var/log/install.txt
-fi
 
-# Copy to S3 so we can put on other instances
-if [ $NOT_EXIST ]; then
-    aws s3 cp /etc/munge/munge.key s3://$CLUSTER_CONFIG_BUCKET/munge.key
+    # base64 decode the munge key and write to file
+    MUNGEKEY_SECRET_DECODED=$(echo $MUNGEKEY_SECRET | base64 -d)
+    cat "$MUNGEKEY_SECRET_DECODED" > /etc/munge/munge.key
 fi
 
 chown munge: /etc/munge/munge.key

--- a/scripts/install_munge.sh
+++ b/scripts/install_munge.sh
@@ -7,6 +7,7 @@ dnf install munge munge-libs munge-devel libssh2-devel sshpass -y -q
 MUNGEKEY_SECRET=$(aws secretsmanager get-secret-value \
     --secret-id "${MUNGEKEY_SECRET_ID}" \
     --query SecretString \
+    --region "${AWS_REGION}" \
     --output text 2> /dev/null) 
 
 if [[ -z $MUNGEKEY_SECRET ]]; then
@@ -23,8 +24,7 @@ else
     echo "munge key already exists, skipping..." >> /var/log/install.txt
 
     # base64 decode the munge key and write to file
-    MUNGEKEY_SECRET_DECODED=$(echo $MUNGEKEY_SECRET | base64 -d)
-    cat "$MUNGEKEY_SECRET_DECODED" > /etc/munge/munge.key
+    echo -n $MUNGEKEY_SECRET | base64 -d > /etc/munge/munge.key
 fi
 
 chown munge: /etc/munge/munge.key

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -5,6 +5,10 @@
 dnf install python3-pip httpd -y -q
 systemctl restart httpd
 
+# Install yq
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq &&\
+chmod +x /usr/bin/yq
+
 wget -O /tmp/ondemand-release-web-3.1-1.amzn2023.noarch.rpm https://yum.osc.edu/ondemand/3.1/ondemand-release-web-3.1-1.amzn2023.noarch.rpm
 dnf install /tmp/ondemand-release-web-3.1-1.amzn2023.noarch.rpm -yq
 dnf update -yq
@@ -114,13 +118,12 @@ if  id "\$1" &> /dev/null; then
     echo "user \$1 home folder doesn't exist, create one " >> /var/log/add_user.log
   #  usermod -a -G spack-users \$1
     sudo mkdir -p /shared/home/\$1 >> /var/log/add_user.log
-    sudo cp /etc/skel/.profile /shared/home/\$1
+    sudo cp /etc/skel/.bash_profile /shared/home/\$1
+    sudo cp /etc/skel/.bashrc /shared/home/\$1
   #  echo "\$1 $(id -u $1)" >> /shared/userlistfile
     sudo chown -R \$1:"Domain Users" /shared/home/$1 >> /var/log/add_user.log
     sudo su \$1 -c 'ssh-keygen -t rsa -f ~/.ssh/id_rsa -q -P ""'
     sudo su \$1 -c 'cat ~/.ssh/id_rsa.pub > ~/.ssh/authorized_keys'
-    sudo su \$1 -c 'echo "[ -f /etc/bashrc ] && . /etc/bashrc" > ~/.bashrc'
-    sudo su \$1 -c 'echo "export PATH" >> ~/.profile'
     sudo chmod 600 /shared/home/\$1/.ssh/*
   fi
 fi
@@ -198,7 +201,7 @@ def run_remote_sbatch(script,host_name, *argv):
     result = ssh(
       '@'.join([USER, host_name]),
       '-oBatchMode=yes',  # ensure that SSH does not hang waiting for a password that will never be sent
-      ',-oUserKnownHostsFile=/dev/null' # ensure that SSH does not try to resolve the hostname of the remote node
+      '-oUserKnownHostsFile=/dev/null', # ensure that SSH does not try to resolve the hostname of the remote node
       '-oStrictHostKeyChecking=no',
       '/opt/slurm/bin/sbatch',  # the real sbatch on the remote
       *argv,  # any arguments that sbatch should get
@@ -268,5 +271,6 @@ cat << EOF >> /var/www/ood/apps/sys/bc_desktop/submit.yml.erb
 batch_connect:
   template: vnc
   websockify_cmd: "/usr/local/bin/websockify"
+  set_host: "host=\$(hostname | awk '{print \$1}').<%= cluster%>.pcluster"
 EOF
 shutdown -r now

--- a/scripts/install_slurm.sh
+++ b/scripts/install_slurm.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-DEBIAN_FRONTEND=noninteractive apt install make build-essential \
-    libmariadb-dev-compat libmariadb-dev libdbus-1-dev -y -q
+dnf install make rpm-build readline-devel \
+    pam-devel perl-Switch perl-ExtUtils\* mariadb105-devel \
+    dbus-devel -y -q
 
 cd /tmp
 wget https://download.schedmd.com/slurm/slurm-"${SLURM_VERSION}".tar.bz2
@@ -22,6 +23,8 @@ cp etc/cgroup.conf.example /etc/slurm/cgroup.conf
 cp etc/slurmd.service /etc/systemd/system
 cp etc/slurmdbd.service /etc/systemd/system
 cp etc/slurmctld.service /etc/systemd/system
+
+chown slurm -R /etc/slurm
 
 # Create slurm user
 useradd slurm

--- a/scripts/mount_efs.sh
+++ b/scripts/mount_efs.sh
@@ -4,10 +4,11 @@
 # Installs amazon-efs-utils (https://github.com/aws/efs-utils)
 
 # Install EFS
+dnf -y install git rpm-build make
 pushd /tmp && git clone https://github.com/aws/efs-utils
 pushd efs-utils
-./build-deb.sh
-apt install ./build/amazon-efs-utils*deb -yq
+make rpm
+dnf install ./build/amazon-efs-utils*rpm -yq
 popd
 
 # # Mount EFS file system

--- a/scripts/mount_efs.sh
+++ b/scripts/mount_efs.sh
@@ -14,6 +14,7 @@ popd
 # # Mount EFS file system
 mkdir /shared
 # Add entry for fstab so mounts on restart
-echo "$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).$EFS_ID.efs.$AWS_REGION.amazonaws.com:/ /shared efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+echo "$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/availability-zone).$EFS_ID.efs.$AWS_REGION.amazonaws.com:/ /shared efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
 mount -a
 mkdir -p /shared/home

--- a/scripts/pcluster_head_node.sh
+++ b/scripts/pcluster_head_node.sh
@@ -16,7 +16,6 @@ OOD_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey
 RDS_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="DBSecretId") | .OutputValue')
 EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
 S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
-MUNGEKEY_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
 
 export RDS_SECRET=$(aws secretsmanager --region $REGION get-secret-value --secret-id $RDS_SECRET_ID --query SecretString --output text)
 export RDS_USER=$(echo $RDS_SECRET | jq -r ".username")
@@ -107,16 +106,6 @@ EOF
 
 chmod 600 /opt/slurm/etc/slurmdbd.conf
 chown slurm /opt/slurm/etc/slurmdbd.conf
-
-# Copy Common Munge Key
-aws secretsmanager get-secret-value \
-    --secret-id "${MUNGEKEY_SECRET}" \
-    --query SecretString \
-    --output text
-    > /etc/munge/munge.key
-chown munge: /etc/munge/munge.key
-chmod 400 /etc/munge/munge.key
-systemctl restart munge
 
 # TODO: Create if doesn't exist (dependson PCluster version)
 #cat <<EOF >> /etc/systemd/system/slurmdbd.service

--- a/scripts/pcluster_head_node.sh
+++ b/scripts/pcluster_head_node.sh
@@ -26,7 +26,7 @@ export RDS_DBNAME=$(echo $RDS_SECRET | jq -r ".dbname")
 
 # Add entry for fstab so mounts on restart
 mkdir /shared
-echo "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v -s http://169.254.169.254/latest/meta-data/placement/availability-zone).${EFS_ID}.efs.$REGION.amazonaws.com:/ /shared efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
+echo "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/placement/availability-zone).${EFS_ID}.efs.$REGION.amazonaws.com:/ /shared efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
 mount -a
 
 # Add spack-users group

--- a/scripts/pcluster_head_node.sh
+++ b/scripts/pcluster_head_node.sh
@@ -16,6 +16,7 @@ OOD_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey
 RDS_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="DBSecretId") | .OutputValue')
 EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
 S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
+MUNGEKEY_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
 
 export RDS_SECRET=$(aws secretsmanager --region $REGION get-secret-value --secret-id $RDS_SECRET_ID --query SecretString --output text)
 export RDS_USER=$(echo $RDS_SECRET | jq -r ".username")
@@ -108,7 +109,11 @@ chmod 600 /opt/slurm/etc/slurmdbd.conf
 chown slurm /opt/slurm/etc/slurmdbd.conf
 
 # Copy Common Munge Key
-aws s3 cp s3://$S3_CONFIG_BUCKET/munge.key /etc/munge/munge.key
+aws secretsmanager get-secret-value \
+    --secret-id "${MUNGEKEY_SECRET}" \
+    --query SecretString \
+    --output text
+    > /etc/munge/munge.key
 chown munge: /etc/munge/munge.key
 chmod 400 /etc/munge/munge.key
 systemctl restart munge

--- a/scripts/pcluster_worker_node.sh
+++ b/scripts/pcluster_worker_node.sh
@@ -13,18 +13,7 @@ OOD_STACK=$(aws cloudformation describe-stacks --stack-name $OOD_STACK_NAME --re
 
 
 S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
-MUNGEKEY_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
 EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
-
-# Copy Common Munge Key
-aws secretsmanager get-secret-value \
-    --secret-id "${MUNGEKEY_SECRET}" \
-    --query SecretString \
-    --output text
-    > /etc/munge/munge.key
-chown munge: /etc/munge/munge.key
-chmod 400 /etc/munge/munge.key
-systemctl restart munge
 
 # Add entry for fstab so mounts on restart
 mkdir /shared

--- a/scripts/pcluster_worker_node.sh
+++ b/scripts/pcluster_worker_node.sh
@@ -13,10 +13,15 @@ OOD_STACK=$(aws cloudformation describe-stacks --stack-name $OOD_STACK_NAME --re
 
 
 S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
+MUNGEKEY_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
 EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
 
 # Copy Common Munge Key
-aws s3 cp s3://$S3_CONFIG_BUCKET/munge.key /etc/munge/munge.key
+aws secretsmanager get-secret-value \
+    --secret-id "${MUNGEKEY_SECRET}" \
+    --query SecretString \
+    --output text
+    > /etc/munge/munge.key
 chown munge: /etc/munge/munge.key
 chmod 400 /etc/munge/munge.key
 systemctl restart munge

--- a/scripts/pcluster_worker_node_desktop.sh
+++ b/scripts/pcluster_worker_node_desktop.sh
@@ -12,10 +12,15 @@ OOD_STACK=$(aws cloudformation describe-stacks --stack-name $OOD_STACK_NAME --re
 
 
 S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
+MUNGEKEY_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
 EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
 
 # Copy Common Munge Key
-aws s3 cp s3://$S3_CONFIG_BUCKET/munge.key /etc/munge/munge.key
+aws secretsmanager get-secret-value \
+    --secret-id "${MUNGEKEY_SECRET}" \
+    --query SecretString \
+    --output text
+    > /etc/munge/munge.key
 chown munge: /etc/munge/munge.key
 chmod 400 /etc/munge/munge.key
 systemctl restart munge

--- a/scripts/pcluster_worker_node_desktop.sh
+++ b/scripts/pcluster_worker_node_desktop.sh
@@ -12,18 +12,7 @@ OOD_STACK=$(aws cloudformation describe-stacks --stack-name $OOD_STACK_NAME --re
 
 
 S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
-MUNGEKEY_SECRET_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
 EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
-
-# Copy Common Munge Key
-aws secretsmanager get-secret-value \
-    --secret-id "${MUNGEKEY_SECRET}" \
-    --query SecretString \
-    --output text
-    > /etc/munge/munge.key
-chown munge: /etc/munge/munge.key
-chmod 400 /etc/munge/munge.key
-systemctl restart munge
 
 # Add entry for fstab so mounts on restart
 mkdir /shared


### PR DESCRIPTION
### Upgrading solution to Open OnDemand v3.1.1

This PR also brings in the following features:

- Migration from Ubuntu 22.04 to Amazon Linux 2023
- Support for handling [Munge key via Secrets Manager](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#yaml-Scheduling-SlurmSettings-MungeKeySecretArn) - _(added in ParallelCluster 3.8.0)_
- Updated Slurm to `23.11.4`
- Added fix for SSH configuration to deal with **host key** warnings when launching interactive desktops
- Clean up README documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
