### PR TITLE
Adding multi-az pcluster sample configuration and bug fix for configure_cluster_for_ood

### DIFF
--- a/cloudformation/openondemand.yml
+++ b/cloudformation/openondemand.yml
@@ -1485,6 +1485,9 @@ Outputs:
   PrivateSubnet1:
     Description: Private Subnet ID
     Value: !Ref PrivateSubnet1
+  PrivateSubnet2:
+    Description: Private Subnet ID
+    Value: !Ref PrivateSubnet2
   ClusterConfigBucket:
     Description: S3 Bucket where Cluster Configuration items are stored
     Value: !Ref ClusterConfigBucket

--- a/scripts/configure_cluster_for_ood.sh
+++ b/scripts/configure_cluster_for_ood.sh
@@ -8,14 +8,16 @@
 set -euo pipefail
 
 # Iterate over the cluster configurations and generate a SSH configuration
-for cluster_config in $(ls -1 /etc/ood/config/clusters.d/*.yml); do
+CLUSTER_COUNT=0
+while IFS= read -r -d '' cluster_config; do
+  CLUSTER_COUNT=$((CLUSTER_COUNT+1))
   cluster_name=$(basename $cluster_config .yml)
 
   # Get the cluster host from the configuration file
   cluster_host=$(yq -r '.v2.login.host' $cluster_config)
   
   # Generate SSH configuration
-  echo "[-] Generating SSH configuration for $cluster_name..."
+  echo "[-] Generating Open OnDemand SSH and Desktop configurations for '$cluster_name'"
   cat << EOF > /etc/ssh/ssh_config.d/ood_${cluster_name}.conf
 Host ${cluster_host}
   LogLevel Error
@@ -35,6 +37,7 @@ attributes:
   bc_queue: "desktop"
   account: "enduser-research-account"
 EOF
-done
+done < <(find /etc/ood/config/clusters.d/ -iname "*.yml" -print0)
 
-echo "[+] SSH configuration generated successfully."
+echo "[-] Open OnDemand configurations completed"
+echo "[-] cluster configurations processed: $CLUSTER_COUNT"

--- a/scripts/create_sample_pcluster_config.sh
+++ b/scripts/create_sample_pcluster_config.sh
@@ -20,7 +20,8 @@ export DOMAIN_2=${4:-"local"}
 export OOD_STACK=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --region $REGION )
 
 export AD_SECRET_ARN=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ADAdministratorSecretARN") | .OutputValue')
-export SUBNET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="PrivateSubnet1") | .OutputValue')
+export SUBNET_1=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="PrivateSubnet1") | .OutputValue')
+export SUBNET_2=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="PrivateSubnet2") | .OutputValue')
 export HEAD_SG=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="HeadNodeSecurityGroup") | .OutputValue')
 export HEAD_POLICY=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="HeadNodeIAMPolicyArn") | .OutputValue')
 export COMPUTE_SG=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ComputeNodeSecurityGroup") | .OutputValue')
@@ -33,7 +34,7 @@ cat << EOF > ../pcluster-config.yml
 HeadNode:
   InstanceType: c5.large
   Networking:
-    SubnetId: $SUBNET
+    SubnetId: $SUBNET_1
     AdditionalSecurityGroups:
       - $HEAD_SG
   LocalStorage:
@@ -66,7 +67,8 @@ Scheduling:
           MaxCount: 4
       Networking:
         SubnetIds:
-          - $SUBNET
+          - $SUBNET_1
+          - $SUBNET_2
         AdditionalSecurityGroups:
           - $COMPUTE_SG
       ComputeSettings:
@@ -94,7 +96,8 @@ Scheduling:
           MaxCount: 10
       Networking:
         SubnetIds:
-          - $SUBNET
+          - $SUBNET_1
+          - $SUBNET_2
         AdditionalSecurityGroups:
           - $COMPUTE_SG
       ComputeSettings:
@@ -112,6 +115,7 @@ Scheduling:
         AdditionalIamPolicies:
           - Policy: >-
               $COMPUTE_POLICY
+
 Region: $REGION
 Image:
   Os: alinux2


### PR DESCRIPTION
*Description of changes:*
- Adding Multi-az support following features to sample pcluster config
- Bugfix to `configure_cluster_for_ood.sh` to no longer fail when there are no yaml configurations are found in `/etc/ood/config/clusters.d`

To use multi-az support for an existing deployment users will need to perform a stack update with the updated CloudFormation template.  The update will add a new output for `PrivateSubnet2`.