### PR TITLE
Update HostedZoneName regex and use HostedZoneId in RecordSet

### DIFF
--- a/assets/cloudformation/ood.yml
+++ b/assets/cloudformation/ood.yml
@@ -14,7 +14,6 @@ Metadata:
       - Label:
           default: Route53
         Parameters:
-          - HostedZoneName
           - HostedZoneId
       - Label:
           default: Networking
@@ -42,8 +41,6 @@ Metadata:
         default: Portal Allowed IP CIDR
       WebsiteDomainName:
         default: Website Domain Name
-      HostedZoneName:
-        default: Hosted Zone Name
       HostedZoneId:
         default: Hosted Zone Id
 Parameters:
@@ -62,13 +59,10 @@ Parameters:
   WebsiteDomainName:
     Description: Domain name for world facing website
     Type: String
-  HostedZoneName:
-    Description: Hosted zone for the domain
-    Type: String
-    AllowedPattern: '[A-Za-z\.]*\.$'
   HostedZoneId:
     Description: Hosted Zone Id for Route53 Domain
     Type: String
+    AllowedPattern: '[A-Za-z\.]*$'
   PortalAllowedIPCIDR:
     Description: IP CIDR for access to the Portal
     Default: 0.0.0.0/0
@@ -912,7 +906,7 @@ Resources:
   DNSRecord:
     Type: AWS::Route53::RecordSet
     Properties:
-      HostedZoneName: !Ref HostedZoneName
+      HostedZoneId: !Ref HostedZoneId
       Name: !Ref WebsiteDomainName
       AliasTarget:
         DNSName: !GetAtt ALB.DNSName

--- a/assets/cloudformation/ood_full.yml
+++ b/assets/cloudformation/ood_full.yml
@@ -11,7 +11,6 @@ Metadata:
       - Label:
           default: Route53
         Parameters:
-          - HostedZoneName
           - HostedZoneId
       - Label:
           default: Active Directory
@@ -28,8 +27,6 @@ Metadata:
         default: Portal Allowed IP CIDR
       WebsiteDomainName:
         default: Website Domain Name
-      HostedZoneName:
-        default: Hosted Zone Name
       HostedZoneId:
         default: Hosted Zone Id
 Parameters:
@@ -48,10 +45,6 @@ Parameters:
   WebsiteDomainName:
     Description: Domain name for world facing website
     Type: String
-  HostedZoneName:
-    Description: Hosted zone for the domain
-    Type: String
-    AllowedPattern: '[A-Za-z\.]*\.$'
   HostedZoneId:
     Description: Hosted Zone Id for Route53 Domain
     Type: String
@@ -91,7 +84,6 @@ Resources:
         PrivateSubnets: !GetAtt [ OODInfra, Outputs.PrivateSubnets ]
         DomainName: !GetAtt [ OODInfra, Outputs.DomainName ]
         TopLevelDomain: !GetAtt [ OODInfra, Outputs.TopLevelDomain ]
-        HostedZoneName: !Ref HostedZoneName
         HostedZoneId: !Ref HostedZoneId
         PortalAllowedIPCIDR: !Ref PortalAllowedIPCIDR
         WebsiteDomainName: !Ref WebsiteDomainName


### PR DESCRIPTION
*Description of changes:*

The regex in HostedZoneName forces it to end in a period, but my HostedZone's name doesn't end in a period. I'm not sure if I'm doing something wrong, or if the regex should be updated?

I swapped to use HostedZoneId because it seems more reliable. Per the documentation:

> Specify either HostedZoneName or HostedZoneId, but not both. If you have multiple hosted zones with the same domain name, you must specify the hosted zone using HostedZoneId. 

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-recordsetgroup-recordset.html#cfn-route53-recordsetgroup-recordset-hostedzonename

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
