### PR TITLE
Improved EFS handling, and fix for slurm configuration during auto-scaling event

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This reference architecture provides a set of templates for deploying [Open OnDemand (OOD)](https://openondemand.org/) with [AWS CloudFormation](https://aws.amazon.com/cloudformation/) and integration points for [AWS Parallel Cluster](https://aws.amazon.com/hpc/parallelcluster/).
 
-The main branch is for Open OnDemand v 3.1.1
+The main branch is for Open OnDemand v 4.0.1
 
 ## Architecture
 
@@ -47,31 +47,40 @@ Once deployed, you should be able to navigate to the URL you set up as a CloudFo
 
 ### Deploying an integrated Parallel Cluster HPC Cluster
 
-The OOD solution is built so that a Parallel Cluster HPC Cluster can be created and automatically registered with the portal.
+The OOD solution is built so that an [AWS ParallelCluster](https://docs.aws.amazon.com/parallelcluster/latest/ug/what-is-aws-parallelcluster.html) HPC Cluster can be created and automatically registered with the portal.
 
 In your Parallel Cluster config, you must set the following values:
 
-1. HeadNode:
-    1. SubnetId: PrivateSubnet1 from OOD Stack Output
-    1. AdditionalScurityGroups: HeadNodeSecurityGroup from CloudFormation Outputs
-    1. AdditionalIAMPolicies: HeadNodeIAMPolicyArn from CloudFormation Outputs
+1. **HeadNode**:
+    1. SubnetId: `PrivateSubnets` from OOD Stack Output
+    1. AdditionalScurityGroups: `HeadNodeSecurityGroup` from CloudFormation Outputs
+    1. AdditionalIAMPolicies: `HeadNodeIAMPolicyArn` from CloudFormation Outputs
     1. OnNodeConfigured
-        1. Script: CloudFormation Output for the ClusterConfigBucket; in the format `s3://$ClusterConfigBucket/pcluster_head_node.sh`
+        1. Script: CloudFormation Output for the `ClusterConfigBucket`; in the format `s3://$ClusterConfigBucket/pcluster_head_node.sh`
         1. Args: Open OnDemand CloudFormation stack name
-1. SlurmQueues:
-    1. SubnetId: PrivateSubnet1 from OOD Stack Output
-    1. AdditionalScurityGroups: ComputeNodeSecurityGroup from CloudFormation Outputs
-    1. AdditionalIAMPolicies: ComputeNodeIAMPolicyArn from CloudFormation Outputs
+1. **SlurmQueues**:
+    1. SubnetId: `PrivateSubnets` from OOD Stack Output
+    1. AdditionalScurityGroups: `ComputeNodeSecurityGroup` from CloudFormation Outputs
+    1. AdditionalIAMPolicies: `ComputeNodeIAMPolicyArn` from CloudFormation Outputs
     1. OnNodeConfigured
-        1. Script: CloudFormation Output for the ClusterConfigBucket; in the format `s3://$ClusterConfigBucket/pcluster_worker_node.sh`
-        1. Args: Open OnDemand CloudFormation stack name
-1. LoginNode:
+        1. Script: CloudFormation Output for the `ClusterConfigBucket`; in the format `s3://$ClusterConfigBucket/pcluster_worker_node.sh`
+        . Args: Open OnDemand CloudFormation stack name
+1. **LoginNode**:
     1. OnNodeConfigured
-        1. Script: CloudFormation Output for the ClusterConfigBucket; in the format `s3://$ClusterConfigBucket/configure_login_nodes.sh`
+        1. Script: CloudFormation Output for the `ClusterConfigBucket`; in the format `s3://$ClusterConfigBucket/configure_login_nodes.sh`
         1. Args: Open OnDemand CloudFormation stack name
 
+---
 
-**Note:** A sample pcluster configuration can be created using [scripts/create_sample_pcluster_config.sh](scripts/create_sample_pcluster_config.sh)
+To make this easier a sample `pcluster` configuration can be created using [scripts/create_sample_pcluster_config.sh](scripts/create_sample_pcluster_config.sh)
+
+```
+Usage: ./scripts/create_sample_pcluster_config.sh <stack-name> [region] [domain1] [domain2]
+  stack-name: The name of the stack you deployed
+  region: The region of the stack you deployed
+  domain1: The first domain name to use for the cluster
+  domain2: The second domain name to use for the cluster
+```
 
 #### Optional - Enable pam_slurm_adopt module for Parallel Cluster compute nodes
 

--- a/assets/cloudformation/infra.yml
+++ b/assets/cloudformation/infra.yml
@@ -355,7 +355,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::dcv-license.${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::cloudformation-waitcondition-${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::al2023-repos-${AWS::Region}-de612dc2/*
-
+              - !Sub arn:${AWS::Partition}:s3:::fsx-lustre-client-repo/*
           - Effect: Allow # Allows access to buckets required for systems manager
             Principal: "*"
             Action: "s3:GetObject"
@@ -369,6 +369,7 @@ Resources:
               - !Sub arn:${AWS::Partition}:s3:::aws-ssm-${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::aws-patchmanager-macos-${AWS::Region}/*
               - !Sub arn:${AWS::Partition}:s3:::al2023-repos-${AWS::Region}-de612dc2/*
+              - !Sub arn:${AWS::Partition}:s3:::fsx-lustre-client-repo/*
 
   ADAdministratorSecret:
     Type: AWS::SecretsManager::Secret

--- a/assets/cloudformation/ood.yml
+++ b/assets/cloudformation/ood.yml
@@ -132,9 +132,8 @@ Parameters:
     Description: Select the verion of slurm to install
     Type: String
     AllowedValues:
-      - "24.05.6"
       - "23.11.10"
-    Default: "24.05.6"
+    Default: "23.11.10"
 
 #######################
 #     Conditions      #

--- a/assets/cloudformation/ood.yml
+++ b/assets/cloudformation/ood.yml
@@ -31,6 +31,9 @@ Metadata:
       - Label: 
           default: Storage
         Parameters:
+          - EFSFileSystemId
+          - EFSFileSystemArn
+          - RetainEFSFileSystem
           - LoadBalancerLogBucket
       - Label:
           default: Slurm Accounting Database
@@ -49,6 +52,11 @@ Metadata:
         default: Website Domain Name
       HostedZoneId:
         default: Hosted Zone Id
+
+#######################
+#     Parameters      #
+#######################
+
 Parameters:
   DomainName:
     Description: Domain name not including the top level domain
@@ -88,14 +96,27 @@ Parameters:
   ADAdministratorSecret:
     Description: AD Admin Secret ARN
     Type: String
-    AllowedPattern: 'arn:aws:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[a-zA-Z0-9/-]*'
+    AllowedPattern: '^(?:arn:aws:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:[A-Za-z0-9\-\_\+\=\/\.\@]{1,519})?$'
   LDAPNLBEndPoint:
     Description: LDAP NLB End Point
     Type: String
   LoadBalancerLogBucket:
-    Description: S3 Bucket to store LB logs
+    Description: S3 Bucket to store Load Balancer logs
     Type: String
     AllowedPattern: '[a-z0-9.-]*'
+  EFSFileSystemId:
+    Description: (Optional) EFS Filesystem Id to mount.  If left blank a file system will be created.
+    Type: String
+  EFSFileSystemArn:
+    Description: (Required if EFSFileSystemId populated) EFS Filesystem Arn.  If left blank a file system will be created.
+    Type: String
+  RetainEFSFileSystem:
+    Description: Retain EFS Filesystem.  If a file system is not provided, this will have no affect
+    Type: String
+    Default: "False"
+    AllowedValues:
+         - "True"
+         - "False"    
   SlurmAccountingDBSecret:
     Description: Slurm Accounting DB Secret ARN
     Type: String
@@ -108,9 +129,24 @@ Parameters:
     Default: main
     Type: String
   SlurmVersion:
-    Description: Verion of slurm to install
-    Default: 23.11.10
+    Description: Select the verion of slurm to install
     Type: String
+    AllowedValues:
+      - "24.05.6"
+      - "23.11.10"
+    Default: "24.05.6"
+
+#######################
+#     Conditions      #
+#######################
+
+Conditions:
+  CreateEFSFileSystem: !Equals [!Ref 'EFSFileSystemId', '']
+  RetainStorage: !Equals [!Ref RetainEFSFileSystem, 'True']
+
+#######################
+#     Reesources      #
+#######################
 
 Resources:
   OODCertificate:
@@ -399,7 +435,7 @@ Resources:
               - elasticfilesystem:ClientWrite
               - elasticfilesystem:ClientRootAccess
             Resource:
-              - !GetAtt SharedFileSystem.Arn
+              - !If [ CreateEFSFileSystem, !GetAtt SharedFileSystem.Arn, !Ref EFSFileSystemArn ]
           - Effect: Allow
             Action:
               - logs:DescribeLogGroups
@@ -505,20 +541,22 @@ Resources:
             /etc/ood-install: !Sub https://github.com/aws-samples/open-on-demand-on-aws/archive/refs/heads/${Branch}.zip
           files: # Creates a file with appropriate variables for use in scripts. No secrets in here
             /etc/ood-install/set_variables.sh:
-              content: !Sub |
-                export AD_SECRET_ID=${OpenOnDemandSecrets}
-                export AD_PASSWORD=${ADAdministratorSecret}
-                export AWS_REGION=${AWS::Region}
-                export DOMAIN_NAME=${DomainName}
-                export TOP_LEVEL_DOMAIN=${TopLevelDomain}
-                export RDS_SECRET_ID=${SlurmAccountingDBSecret}
-                export ALB_DNS_NAME=${ALB.DNSName}
-                export WEBSITE_DOMAIN=${WebsiteDomainName}
-                export LDAP_NLB=${LDAPNLBEndPoint}
-                export EFS_ID=${SharedFileSystem}
-                export CLUSTER_CONFIG_BUCKET=${ClusterConfigBucket}
-                export SLURM_VERSION=${SlurmVersion}
-                export MUNGEKEY_SECRET_ID=${MungeKeySecret}
+              content: !Sub 
+                - |
+                  export AD_SECRET_ID=${OpenOnDemandSecrets}
+                  export AD_PASSWORD=${ADAdministratorSecret}
+                  export AWS_REGION=${AWS::Region}
+                  export DOMAIN_NAME=${DomainName}
+                  export TOP_LEVEL_DOMAIN=${TopLevelDomain}
+                  export RDS_SECRET_ID=${SlurmAccountingDBSecret}
+                  export ALB_DNS_NAME=${ALB.DNSName}
+                  export WEBSITE_DOMAIN=${WebsiteDomainName}
+                  export LDAP_NLB=${LDAPNLBEndPoint}
+                  export EFS_ID=${EFS_FileSystemId}
+                  export CLUSTER_CONFIG_BUCKET=${ClusterConfigBucket}
+                  export SLURM_VERSION=${SlurmVersion}
+                  export MUNGEKEY_SECRET_ID=${MungeKeySecret}
+                - EFS_FileSystemId: !If [ CreateEFSFileSystem, !Ref SharedFileSystem, !Ref EFSFileSystemId ]
               mode: "000744"
               owner: "root"
               group: "root"
@@ -698,7 +736,10 @@ Resources:
           IpProtocol: "-1"
 
   SharedFileSystem:
+    Condition: CreateEFSFileSystem
     Type: AWS::EFS::FileSystem
+    DeletionPolicy: !If [ RetainStorage, Retain, Delete ]
+    UpdateReplacePolicy: !If [ RetainStorage, Retain, Delete ]
     Properties:
       Encrypted: true
       PerformanceMode: generalPurpose
@@ -706,7 +747,7 @@ Resources:
   MountTargetResource1:
     Type: AWS::EFS::MountTarget
     Properties:
-      FileSystemId: !Ref SharedFileSystem
+      FileSystemId: !If [ CreateEFSFileSystem, !GetAtt SharedFileSystem.Arn, !Ref EFSFileSystemArn ]
       SubnetId: !Select [0, !Ref PrivateSubnets]
       SecurityGroups:
         - !Ref MountTargetSecurityGroup
@@ -714,7 +755,7 @@ Resources:
   MountTargetResource2:
     Type: AWS::EFS::MountTarget
     Properties:
-      FileSystemId: !Ref SharedFileSystem
+      FileSystemId: !If [ CreateEFSFileSystem, !GetAtt SharedFileSystem.Arn, !Ref EFSFileSystemArn ]
       SubnetId: !Select [1, !Ref PrivateSubnets]
       SecurityGroups:
         - !Ref MountTargetSecurityGroup
@@ -997,7 +1038,7 @@ Resources:
               - elasticfilesystem:ClientWrite
               - elasticfilesystem:ClientRootAccess
             Resource:
-              - !GetAtt SharedFileSystem.Arn
+              - !If [ CreateEFSFileSystem, !GetAtt SharedFileSystem.Arn, !Ref EFSFileSystemArn ]
           - Effect: Allow
             Action:
               - cloudformation:Describe*
@@ -1022,7 +1063,7 @@ Resources:
               - elasticfilesystem:ClientWrite
               - elasticfilesystem:ClientRootAccess
             Resource:
-              - !GetAtt SharedFileSystem.Arn
+              - !If [ CreateEFSFileSystem, !GetAtt SharedFileSystem.Arn, !Ref EFSFileSystemArn ]
           - Effect: Allow
             Action:
               - cloudformation:Describe* # TODO: Scope down
@@ -1042,6 +1083,11 @@ Resources:
               - kms:Decrypt
               - kms:DescribeKey
             Resource: "*"
+
+#######################
+#     Outputs         #
+#######################
+
 Outputs:
   URL:
     Description: URL
@@ -1069,7 +1115,7 @@ Outputs:
     Value: !Ref MungeKeySecret
   EFSMountId:
     Description: EFS Mount ID
-    Value: !Ref SharedFileSystem
+    Value: !If [ CreateEFSFileSystem, !Ref SharedFileSystem, !Ref EFSFileSystemId ]
   HeadNodeIAMPolicyArn:
     Description: Parallel Cluster Head Node IAM ARN
     Value: !Ref HeadNodeParallelClusterIAMPolicy

--- a/assets/cloudformation/ood.yml
+++ b/assets/cloudformation/ood.yml
@@ -730,9 +730,16 @@ Resources:
           SourceSecurityGroupId: !GetAtt ComputeNodeSecurityGroup.GroupId
           Description: Ingress Rule for ComputeNode
       SecurityGroupEgress:
-        - Description: Remove default rule for egress
-          CidrIp: 127.0.0.1/32
-          IpProtocol: "-1"
+        - IpProtocol: tcp
+          Description: Egress rule for HeadNode
+          FromPort: 2049
+          ToPort: 2049
+          DestinationSecurityGroupId: !GetAtt HeadNodeSecurityGroup.GroupId
+        - IpProtocol: tcp 
+          Description: Egress rule for ComputeNodeSecurityGroup
+          FromPort: 2049
+          ToPort: 2049
+          DestinationSecurityGroupId: !GetAtt ComputeNodeSecurityGroup.GroupId
 
   SharedFileSystem:
     Condition: CreateEFSFileSystem

--- a/scripts/create_sample_pcluster_config.sh
+++ b/scripts/create_sample_pcluster_config.sh
@@ -17,6 +17,16 @@ export DOMAIN_1=${3:-"hpclab"}
 export DOMAIN_2=${4:-"local"}
 PCLUSTER_FILENAME="pcluster-config.yml"
 
+# Generate help 
+if [ "$1" == "--help" ]; then
+  echo "Usage: $0 <stack-name> [region] [domain1] [domain2]"
+  echo "  stack-name: The name of the stack you deployed"
+  echo "  region: The region of the stack you deployed"
+  echo "  domain1: The first domain name to use for the cluster"
+  echo "  domain2: The second domain name to use for the cluster"
+  exit 0
+fi
+
 echo "[-] Checking if stack '$STACK_NAME' exists in region '$REGION'..."
 if ! aws cloudformation describe-stacks --stack-name $STACK_NAME --region $REGION &>/dev/null ; then
     echo "Error: Failed to describe stack '$STACK_NAME' in region '$REGION'. Please check your stack name and region."

--- a/scripts/create_sample_pcluster_config.sh
+++ b/scripts/create_sample_pcluster_config.sh
@@ -13,8 +13,7 @@ if [ -z "$STACK_NAME" ]; then
 fi
 
 export REGION=${2:-"us-east-1"}
-export DOMAIN_1=${3:-"hpclab"}
-export DOMAIN_2=${4:-"local"}
+export AD_DOMAIN=${3:-"DC=hpclab,DC=local"}
 PCLUSTER_FILENAME="pcluster-config.yml"
 
 # Generate help 
@@ -22,8 +21,7 @@ if [ "$1" == "--help" ]; then
   echo "Usage: $0 <stack-name> [region] [domain1] [domain2]"
   echo "  stack-name: The name of the stack you deployed"
   echo "  region: The region of the stack you deployed"
-  echo "  domain1: The first domain name to use for the cluster"
-  echo "  domain2: The second domain name to use for the cluster"
+  echo "  ad_domain: The LDAP DN (e.g. DC=hpclab,DC=local)"
   exit 0
 fi
 
@@ -44,6 +42,7 @@ export COMPUTE_POLICY=$(echo "$OOD_STACK" | jq -r '.Stacks[].Outputs[] | select(
 export BUCKET_NAME=$(echo "$OOD_STACK" | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
 export LDAP_ENDPOINT=$(echo "$OOD_STACK" | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="LDAPNLBEndPoint") | .OutputValue')
 export MUNGEKEY_SECRET_ID=$(echo "$OOD_STACK" | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="MungeKeySecretId") | .OutputValue')
+export SHARED_FILESYSTEMID=$(echo "$OOD_STACK" | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
 
 cat << EOF 
 [+] Using the following values to generate $PCLUSTER_FILENAME
@@ -153,6 +152,8 @@ cat << EOF >> $PCLUSTER_FILENAME
 EOF
 done
 
+AD_OU=$(echo $AD_DOMAIN | sed 's/DC=\([^,]*\).*/\1/')
+
 cat << EOF >> $PCLUSTER_FILENAME
         AdditionalSecurityGroups:
           - $COMPUTE_SG
@@ -192,16 +193,23 @@ LoginNodes:
           - Policy: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
           - Policy: arn:aws:iam::aws:policy/AmazonS3FullAccess
           - Policy: arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
-          - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess              
+          - Policy: arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+SharedStorage:
+  - MountDir: /shared
+    Name: shared-storage
+    StorageType: Efs
+    EfsSettings:
+      FileSystemId: ${SHARED_FILESYSTEMID}
 Region: $REGION
 Image:
   Os: alinux2
 DirectoryService:
-  DomainName: $DOMAIN_1.$DOMAIN_2
+  DomainName: $AD_DOMAIN
   DomainAddr: ldap://$LDAP_ENDPOINT
   PasswordSecretArn: $AD_SECRET_ARN
-  DomainReadOnlyUser: cn=Admin,ou=Users,ou=$DOMAIN_1,dc=$DOMAIN_1,dc=$DOMAIN_2
+  DomainReadOnlyUser: cn=Admin,ou=Users,ou=$AD_OU,$AD_DOMAIN
   AdditionalSssdConfigs:
     override_homedir: /shared/home/%u
+    use_fully_qualified_names: False
     ldap_auth_disable_tls_never_use_in_production: true
 EOF

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -90,6 +90,12 @@ node_uri: '/node'
 rnode_uri: '/rnode'
 EOF
 
+mkdir /etc/ood/config/ondemand.d
+cat << EOF >> /etc/ood/config/ondemand.d/aws-branding.yml
+dashboard_title: 'Open OnDemand on AWS'
+brand_bg_color: '#ff7f0e'
+EOF
+
 # # Tells PUN to look for home directories in EFS
 cat << EOF >> /etc/ood/config/nginx_stage.yml
 user_home_dir: '/shared/home/%{user}'

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -90,7 +90,7 @@ node_uri: '/node'
 rnode_uri: '/rnode'
 EOF
 
-mkdir /etc/ood/config/ondemand.d
+mkdir -p /etc/ood/config/ondemand.d
 cat << EOF >> /etc/ood/config/ondemand.d/aws-branding.yml
 dashboard_title: 'Open OnDemand on AWS'
 brand_bg_color: '#ff7f0e'

--- a/scripts/install_slurm.sh
+++ b/scripts/install_slurm.sh
@@ -135,7 +135,7 @@ AccountingStoragePort=6819
 EOF
 else
     echo "[-] slurmdbd.conf found, updating hosts"
-    sed -i "s/AccountingStorageHost=.*$/AccountingStorageHost=$(hostname -s)/" /etc/slurm/slurmd.conf
+    sed -i "s/AccountingStorageHost=.*$/AccountingStorageHost=$(hostname -s)/" /etc/slurm/slurm.conf
 fi
 
 cp etc/slurmdbd.service /etc/systemd/system

--- a/scripts/install_slurm.sh
+++ b/scripts/install_slurm.sh
@@ -135,7 +135,7 @@ AccountingStoragePort=6819
 EOF
 else
     echo "[-] slurmdbd.conf found, updating hosts"
-    sed -i "s/AccountingStorageHost=.*$/AccountingStorageHost=$(hostname -s)/" /etc/slurm/slurmdbd.conf
+    sed -i "s/AccountingStorageHost=.*$/AccountingStorageHost=$(hostname -s)/" /etc/slurm/slurmd.conf
 fi
 
 cp etc/slurmdbd.service /etc/systemd/system

--- a/scripts/install_slurm.sh
+++ b/scripts/install_slurm.sh
@@ -135,6 +135,7 @@ AccountingStoragePort=6819
 EOF
 else
     echo "[-] slurmdbd.conf found, updating hosts"
+    sed -i "s/DbdHost=.*$/DbdHost=$(hostname -s)/" /etc/slurm/slurmdbd.conf
     sed -i "s/AccountingStorageHost=.*$/AccountingStorageHost=$(hostname -s)/" /etc/slurm/slurm.conf
 fi
 

--- a/scripts/install_slurm.sh
+++ b/scripts/install_slurm.sh
@@ -60,6 +60,10 @@ if [ ! -f /etc/slurm/slurm.conf ]; then
 
     sed -i "s/SlurmctldHost=.*$/SlurmctldHost=$(hostname -s)/" /etc/slurm/slurm.conf
     sed -i "s/NodeName=.*$/NodeName=$(hostname -s)/" /etc/slurm/slurm.conf
+else
+    echo "[-] slurm.conf found, updating hosts"
+    sed -i "s/SlurmctldHost=.*$/SlurmctldHost=$(hostname -s)/" /etc/slurm/slurm.conf
+    sed -i "s/NodeName=.*$/NodeName=$(hostname -s)/" /etc/slurm/slurm.conf    
 fi
 
 # Add hostname -s to /etc/hosts
@@ -129,6 +133,9 @@ AccountingStorageHost=$(hostname -s)
 AccountingStorageUser=$RDS_USER
 AccountingStoragePort=6819
 EOF
+else
+    echo "[-] slurmdbd.conf found, updating hosts"
+    sed -i "s/AccountingStorageHost=.*$/AccountingStorageHost=$(hostname -s)/" /etc/slurm/slurmdbd.conf
 fi
 
 cp etc/slurmdbd.service /etc/systemd/system

--- a/scripts/pcluster_worker_node.sh
+++ b/scripts/pcluster_worker_node.sh
@@ -2,37 +2,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-yum -y -q install jq amazon-efs-utils
-
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-# Get OOD Stack data
-OOD_STACK_NAME=$1
-REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/placement/region)
-
-OOD_STACK=$(aws cloudformation describe-stacks --stack-name $OOD_STACK_NAME --region $REGION )
-
-
-S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
-EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
-
-# Add entry for fstab so mounts on restart
-mkdir /shared
-echo "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v -s http://169.254.169.254/latest/meta-data/placement/availability-zone).${EFS_ID}.efs.$REGION.amazonaws.com:/ /shared efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
-mount -a
-
 # Add spack-users group
 groupadd spack-users -g 4000
-
-# change to using ad user login, this is no longer needed 
-#/shared/copy_users.sh
-
-#fix the sssd script so getent passws command can find the domain user
-#This line allows the users to login without the domain name
-sed -i 's/use_fully_qualified_names = True/use_fully_qualified_names = False/g' /etc/sssd/sssd.conf
-#This line configure sssd to create the home directories in the shared folder
-sed -i 's/fallback_homedir = \/home\/%u/fallback_homedir = \/shared\/home\/%u/' -i /etc/sssd/sssd.conf
-sleep 1
-systemctl restart sssd
 
 cat >> /etc/bashrc << 'EOF'
 PATH=$PATH:/shared/software/bin

--- a/scripts/pcluster_worker_node_desktop.sh
+++ b/scripts/pcluster_worker_node_desktop.sh
@@ -2,36 +2,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-yum -y -q install jq amazon-efs-utils
-# Get OOD Stack data
-TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-OOD_STACK_NAME=$1
-REGION=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v http://169.254.169.254/latest/meta-data/placement/region)
-
-OOD_STACK=$(aws cloudformation describe-stacks --stack-name $OOD_STACK_NAME --region $REGION )
-
-
-S3_CONFIG_BUCKET=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="ClusterConfigBucket") | .OutputValue')
-EFS_ID=$(echo $OOD_STACK | jq -r '.Stacks[].Outputs[] | select(.OutputKey=="EFSMountId") | .OutputValue')
-
-# Add entry for fstab so mounts on restart
-mkdir /shared
-echo "$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -v -s http://169.254.169.254/latest/meta-data/placement/availability-zone).${EFS_ID}.efs.$REGION.amazonaws.com:/ /shared efs _netdev,noresvport,tls,iam 0 0" >> /etc/fstab
-mount -a
-
+yum -y -q install jq 
 # Add spack-users group
 groupadd spack-users -g 4000
-
-# change to using ad user login, this is no longer needed 
-#/shared/copy_users.sh
-
-#fix the sssd script so getent passws command can find the domain user
-#This line allows the users to login without the domain name
-sed -i 's/use_fully_qualified_names = True/use_fully_qualified_names = False/g' /etc/sssd/sssd.conf
-#This line configure sssd to create the home directories in the shared folder
-sed -i 's/fallback_homedir = \/home\/%u/fallback_homedir = \/shared\/home\/%u/' -i /etc/sssd/sssd.conf
-sleep 1
-systemctl restart sssd
 
 ## install remote desktop packages
 ## uncomment the following if you want to run interacctive remote desktop session in OOD


### PR DESCRIPTION
*Description of changes:*

## Improved the EFS handling 
Users can 'bring your own' EFS file system or allow deployment to create one.  A `DeletionPolicy` has also been added to allow for retainment of EFS file system.

## Bugfix for slurm configuration
There was an issue discovered that if the OOD ec2 instance was terminated, the slurm/slurmdbd configurations were not updated with the appropriate `host` values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
