### PR TITLE
Send serveralive message to keep SSH session alive on login node

### DIFF
--- a/assets/cloudformation/ood.yml
+++ b/assets/cloudformation/ood.yml
@@ -496,7 +496,7 @@ Resources:
         - Key: access_logs.s3.prefix
           Value: portal-alb
         - Key: idle_timeout.timeout_seconds # Required to address issue with OOD SSH timeout
-          Value: 600          
+          Value: 600
 
   # Add a new secrets manager entry
   MungeKeySecret:

--- a/scripts/configure_cluster_for_ood.sh
+++ b/scripts/configure_cluster_for_ood.sh
@@ -24,6 +24,8 @@ Host ${cluster_host}
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
   PasswordAuthentication no
+	ServerAliveInterval 60
+ 	ServerAliveCountMax 5
 EOF
 
   # Add open ondemand desktop configuration


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Send serveralive message to keep SSH session alive on login node

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
