### PR TITLE
Fixes slurm cluster registration and myjobs on HTTP

### DIFF
--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -110,7 +110,13 @@ if [ "$OOD_HTTP" = "true" ]; then
   # Modify the myjobs initializer 
   # change the session store to address CRSF errors when using HTTP
   mkdir -p /etc/ood/config/apps/myjobs/initializers
-  
+  # Modify the myjobs initializer in /var/www/ood/apps/sys/myjobs/config/initializers/session_store.rb
+  # to use cookie_store instead of the default cache_store
+  cat << EOF > /var/www/ood/apps/sys/myjobs/config/initializers/session_store.rb
+# change the session store to address CRSF errors when using HTTP
+Rails.application.config.session_store :cookie_store, key: '_myjobs_session', secure: false
+EOF
+
   cat << EOF >> /etc/ood/config/apps/myjobs/initializers/session_store.rb
 # change the session store to address CRSF errors when using HTTP
 Rails.application.config.session_store :cookie_store, key: '_myjobs_session', secure: false

--- a/scripts/install_ood.sh
+++ b/scripts/install_ood.sh
@@ -110,10 +110,14 @@ if [ "$OOD_HTTP" = "true" ]; then
   # Modify the myjobs initializer 
   # change the session store to address CRSF errors when using HTTP
   mkdir -p /etc/ood/config/apps/myjobs/initializers
+  
   cat << EOF >> /etc/ood/config/apps/myjobs/initializers/session_store.rb
 # change the session store to address CRSF errors when using HTTP
 Rails.application.config.session_store :cookie_store, key: '_myjobs_session', secure: false
 EOF
+
+  # Restart httpd to pick up the changes
+  systemctl restart httpd
 fi
 
 mkdir -p /etc/ood/config/ondemand.d

--- a/scripts/pcluster_head_node.sh
+++ b/scripts/pcluster_head_node.sh
@@ -127,6 +127,7 @@ systemctl daemon-reload
 systemctl enable slurmdbd
 systemctl start slurmdbd
 
+sleep 10
 echo "Adding '$CLUSTER_NAME' to slurm accounting"
 systemctl start slurmctld
 sacctmgr --quiet add cluster $CLUSTER_NAME


### PR DESCRIPTION
*Description of changes:*
fix: Sleep after restarting slurmdbd to catch instances where cluster isn't registered
fix[ood-install]: Restart httpd after modifying session store for HTTP

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
