### PR TITLE
Fix CFN parameters

### DIFF
--- a/assets/cloudformation/ood.yml
+++ b/assets/cloudformation/ood.yml
@@ -136,6 +136,7 @@ Parameters:
   MungeKeySecretArn:
     Description: (Optional) Munge Key Secret ARN.  If left blank a munge key will be created.
     Type: String
+    Default: ""
   Branch:
     Description: Branch of the code to deploy. Only use this when testing changes to the solution
     Default: main

--- a/assets/cloudformation/ood_full.yml
+++ b/assets/cloudformation/ood_full.yml
@@ -102,12 +102,14 @@ Resources:
         VPC: !GetAtt [ OODInfra, Outputs.VPCId ]
         PublicSubnets: !GetAtt [ OODInfra, Outputs.PublicSubnets ]
         PrivateSubnets: !GetAtt [ OODInfra, Outputs.PrivateSubnets ]
+        PCSClusterSecurityGroup: !GetAtt [ OODInfra, Outputs.HPCClusterSecurityGroup ]
         DomainName: !GetAtt [ OODInfra, Outputs.DomainName ]
         TopLevelDomain: !GetAtt [ OODInfra, Outputs.TopLevelDomain ]
         HostedZoneId: !Ref HostedZoneId
         PortalAllowedIPCIDR: !Ref PortalAllowedIPCIDR
         WebsiteDomainName: !Ref WebsiteDomainName
         SlurmAccountingDBSecret: !GetAtt [ OODSlurmAccountingDB, Outputs.DBSecretId ]
+        SlurmAccountingDBSecretPassword: !GetAtt [ OODSlurmAccountingDB, Outputs.DBSecretPassword ]
         SlurmAccountingDBSecurityGroup: !GetAtt [ OODSlurmAccountingDB, Outputs.DBSecurityGroup ]
         ADAdministratorSecret: !GetAtt [ OODInfra, Outputs.ADAdministratorSecretARN ]
         LDAPNLBEndPoint: !GetAtt [ OODInfra, Outputs.LDAPNLBEndPoint ]


### PR DESCRIPTION
*Issue #, if available:*

Error when deploying ood_full.yaml stack. Missing parameters:

- `PCSClusterSecurityGroup`
- `SlurmAccountingDBSecretPassword`
- `MungeKeySecretArn`

<img width="729" alt="Screenshot 2025-06-20 at 10 41 45 AM" src="https://github.com/user-attachments/assets/fec48810-9589-4f51-873f-943903878bd3" />

*Description of changes:*

- `PCSClusterSecurityGroup` - added parameter based on **OODInfra** stack output in ood_full.yaml.
- `SlurmAccountingDBSecretPassword` - added parameter based on **OODSlurmAccountingDB** stack output in ood_full.yaml.
- `MungeKeySecretArn` - added default value of `""` in ood.yaml.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
